### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ dependencies {
 **0.3**
 * add multi touch support
 
-##LICENSE
+## LICENSE
 ```
 Copyright 2015 Asha
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
